### PR TITLE
v0.1 - Saving and loading, refactored code, changed show boards button and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,29 @@ This repository is for a webpage about taking notes on chess openings.
 
 The goal is to make a webpage where the user can write down about certain openings they want to study/memorize about in a tree-like structure with comments on each move.
 
-To Do:
-- [ ] Add saving and loading via local storage
-- [ ] Add user input
-- [ ] Better visuals/customizability
-  - [ ] Animations
-  - [ ] Light mode
-  - [ ] Board/Pieces Themes
+To do:
+- Higher priority:
+  - [x] Add saving and loading via local storage
+  - [ ] Add user input
+  - [ ] Better visuals/customizability
+    - [ ] Animations
+    - [ ] Light mode
+    - [ ] Board/Pieces Themes
+- Less priority:
+  - [ ] Fix show boards button
+
+Latest changes (v0.1):
+- Added saving and loading of the page using states and `window.localStorage`
+  - State classes: `MoveBoxState`, `MoveSetState`, `PageState`
+  - State getting functions: `getMoveBoxState`, `getMoveSetState`, `getState`
+  - State manipulation functions: `saveState`, `clearState`
+  - State loading functions: `loadState`, `createMoveBox`, `createMoveSetContainer`
+  - Other functions: `readState`, `clearContent`
+- Refactored parts of the code as functions so they can be used when loading states
+  - Initialization functions: `initMoveBoard`, `initMoveBox`, `initShowBoardsButton`, `initMoveSet`, `initMoveSetContainer`
+- Changed show boards button to not use a board character and instead have a background of a board (still has problems on Firefox and has inexact measures)
+  - Added to do item about fixing the button (probably changing to an image)
+- Added wrapping to the description of move boxes for later input capabilities
+  - Changed HTML accordingly
+- Added margin to move boxes that aren't children of move sets
+- Added type documentation to `createSquare` function

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Latest changes (v0.1):
   - Initialization functions: `initMoveBoard`, `initMoveBox`, `initShowBoardsButton`, `initMoveSet`, `initMoveSetContainer`
 - Changed show boards button to not use a board character and instead have a background of a board (still has problems on Firefox and has inexact measures)
   - Added to do item about fixing the button (probably changing to an image)
+- Fixed move classification path to images
 - Added wrapping to the description of move boxes for later input capabilities
   - Changed HTML accordingly
 - Added margin to move boxes that aren't children of move sets

--- a/chess-opening-preparation/css/style.css
+++ b/chess-opening-preparation/css/style.css
@@ -99,43 +99,43 @@ header {
 }
 
 .move-classification.brilliant {
-    background-image: url("images/brilliant.svg");
+    background-image: url("../images/brilliant.svg");
 }
 
 .move-classification.great_find {
-    background-image: url("images/great_find.svg");
+    background-image: url("../images/great_find.svg");
 }
 
 .move-classification.best {
-    background-image: url("images/best.svg");
+    background-image: url("../images/best.svg");
 }
 
 .move-classification.excellent {
-    background-image: url("images/excellent.svg");
+    background-image: url("../images/excellent.svg");
 }
 
 .move-classification.good {
-    background-image: url("images/good.svg");
+    background-image: url("../images/good.svg");
 }
 
 .move-classification.book {
-    background-image: url("images/book.svg");
+    background-image: url("../images/book.svg");
 }
 
 .move-classification.inaccuracy {
-    background-image: url("images/inaccuracy.svg");
+    background-image: url("../images/inaccuracy.svg");
 }
 
 .move-classification.mistake {
-    background-image: url("images/mistake.svg");
+    background-image: url("../images/mistake.svg");
 }
 
 .move-classification.incorrect {
-    background-image: url("images/incorrect.svg");
+    background-image: url("../images/incorrect.svg");
 }
 
 .move-classification.blunder {
-    background-image: url("images/blunder.svg");
+    background-image: url("../images/blunder.svg");
 }
 
 .move-board {

--- a/chess-opening-preparation/css/style.css
+++ b/chess-opening-preparation/css/style.css
@@ -88,8 +88,13 @@ header {
     border-color: var(--main-color-500);
 }
 
+main > .move-box {
+    margin: var(--border-size) var(--border-size) 0 var(--border-size);
+}
+
 .move-box > p {
     text-wrap: wrap;
+    white-space: pre-wrap;
 }
 
 .move-classification {
@@ -224,38 +229,61 @@ header {
     background-color: var(--main-color-500);
     padding: calc(var(--border-size) * 2);
     border-radius: calc(var(--border-size) * 2) calc(var(--border-size) * 2) 0 0;
-    font-size: 1.333em;
+    font-size: calc(4em / 3);
 }
 
 .move-set-title > h2 {
     display: inline-block;
     font-weight: inherit;
     font-size: inherit;
+    height: calc(4em / 3);
 }
 
 .show-boards {
-    background: var(--board-dark-color);
+    background-color: var(--board-dark-color);
+    padding: 0.1em;
     border: 0.1em solid var(--board-light-color);
-    color: var(--board-light-color);
     cursor: pointer;
     display: inline-block;
     font-size: inherit;
     user-select: none;
-    line-height: 1;
-    padding: 0.05em 0.1em 0.2em 0.1em;
+    height: calc(4em / 3);
+    aspect-ratio: 1 / 1;
     opacity: 50%;
 }
 
+.show-boards-icon {
+    display: inline-block;
+    width: 100%;
+    height: 100%;
+    background: 
+        linear-gradient(45deg, var(--board-light-color) 25%, transparent 25%, transparent 75%, var(--board-light-color) 75%),
+        linear-gradient(45deg, var(--board-light-color) 25%, transparent 25%, transparent 75%, var(--board-light-color) 75%);
+    background-position: 0 0, calc(1.4em / 3) calc(1.4em / 3);
+}
+
 .show-boards:hover {
-    background: var(--board-darker-dark-color);
+    background-color: var(--board-darker-dark-color);
     border-color: var(--board-darker-light-color);
-    color: var(--board-darker-light-color);
+}
+
+.show-boards:hover .show-boards-icon {
+    background: 
+        linear-gradient(45deg, var(--board-darker-light-color) 25%, transparent 25%, transparent 75%, var(--board-darker-light-color) 75%),
+        linear-gradient(45deg, var(--board-darker-light-color) 25%, transparent 25%, transparent 75%, var(--board-darker-light-color) 75%);
+    background-position: 0 0, calc(1.4em / 3) calc(1.4em / 3);
 }
 
 .show-boards:active {
-    background: var(--board-darker-light-color);
+    background-color: var(--board-darker-light-color);
     border-color: var(--board-darker-dark-color);
-    color: var(--board-darker-dark-color);
+}
+
+.show-boards:active .show-boards-icon {
+    background: 
+        linear-gradient(45deg, var(--board-darker-dark-color) 25%, transparent 25%, transparent 75%, var(--board-darker-dark-color) 75%),
+        linear-gradient(45deg, var(--board-darker-dark-color) 25%, transparent 25%, transparent 75%, var(--board-darker-dark-color) 75%);
+    background-position: 0 0, calc(1.4em / 3) calc(1.4em / 3);
 }
 
 .show-boards[data-hide-boards='true'] {

--- a/chess-opening-preparation/index.html
+++ b/chess-opening-preparation/index.html
@@ -12,12 +12,15 @@
     </header>
     <main>
         <button class="move-box">
-            <p>Bb5 pinning Knight:<br>- Bd6 O-O (Best)<br>- a6 xc6+ bxc6<br>- Others: don't take</p>
+            <p>Bb5 pinning Knight:
+- Bd6 O-O (Best)
+- a6 xc6+ bxc6
+- Others: don't take</p>
             <div class="move-board" data-fen="r2qkbnr/ppp2ppp/2n1p3/1B1p1b2/3P1B2/4PN2/PPP2PPP/RN1QK2R w KQkq - 0 1" data-perspective="b" data-move-start="f1" data-move-end="b5"></div>
         </button>
         <div class="move-set-container">
             <div class="move-set-title">
-                <h2>London System Mainline</h2> <button class="show-boards">🙾</button>
+                <h2>London System Mainline</h2> <button class="show-boards"><div class="show-boards-icon"></div></button>
             </div>
             
             <div class="move-set">

--- a/chess-opening-preparation/js/script.js
+++ b/chess-opening-preparation/js/script.js
@@ -1,160 +1,248 @@
-/**
- * @return {void}
- */
-function toggleShowBoardsMode() {
-    document.querySelectorAll('.move-set-title').forEach(title => {
-        let showBoardsButton = title.querySelector('.show-boards');
-        let hideBoards = false;
+class MoveBoxState {
+    type = 'box';
 
-        let set = title.nextElementSibling
+    /**
+     * @param {string} description
+     * @param {string} fen
+     * @param {string} perspective
+     * @param {string} moveStart
+     * @param {string} moveEnd
+     * @param {(string|null)} branch
+     * @param {(string|null)} moveClassification
+     */
+    constructor(description, fen, perspective, moveStart, moveEnd, branch, moveClassification) {
+        this.description = description
+        this.fen = fen
+        this.perspective = perspective
+        this.moveStart = moveStart
+        this.moveEnd = moveEnd
+        this.branch = branch
+        this.moveClassification = moveClassification
+    }
 
-        if (set.querySelector('.move-box[data-show-board="false"]')) {
-            hideBoards = true;
-        }
-
-        showBoardsButton.setAttribute('data-hide-boards', hideBoards ? 'false' : 'true');
-    });
+    /**
+     * 
+     * @param {Object} object 
+     * @returns {MoveBoxState}
+     */
+    static from(object) {
+        return Object.assign(new MoveBoxState(), object);
+    }
 }
-
-/**
- * @param {Element} box 
- * @return {void}
- */
-function switchShowBoard(box) {
-    box.setAttribute('data-show-board', box.getAttribute('data-show-board') === 'false' ? 'true' : 'false');
-}
-
-document.querySelectorAll('.move-box').forEach(box => {
-    box.setAttribute('data-show-board', 'false');
-
-    box.addEventListener('click', () => {
-        switchShowBoard(box);
-    })
-});
 
 /**
  * @param {Element} box
- * @return {void}
+ * @returns {MoveBoxState}
  */
-function updateMoveBoxHeight(box) {
-    if (box.getAttribute('data-show-board') === 'true') {
-        if (box.style.height !== '') {
-            box.style.height = ''
-        }
-    } else {
-        let height = `calc(${box.querySelector('p').clientHeight}px + 4 * var(--border-size))`
+function getMoveBoxState(box) {
+    let board = box.querySelector('.move-board');
 
-        if (box.style.height !== height) {
-            box.style.height = height
+    let moveClassification = box.querySelector('.move-classification');
+
+    let state = new MoveBoxState(
+        box.querySelector('p').textContent,
+        board.getAttribute('data-fen'),
+        board.getAttribute('data-perspective'),
+        board.getAttribute('data-move-start'),
+        board.getAttribute('data-move-end'),
+        box.getAttribute('data-branch'),
+        moveClassification === null ? null : moveClassification.classList.values().filter((cls) => cls !== 'move-classification').next().value
+    );
+
+    return state;
+}
+
+
+class MoveSetState {
+    type = 'set';
+
+    /**
+     * @param {string} title
+     * @param {MoveBoxState[]} moveBoxes
+     */
+    constructor(title, moveBoxes) {
+        this.title = title
+        this.moveBoxes = moveBoxes
+    }
+
+    /**
+     * 
+     * @param {Object} object 
+     * @returns {MoveSetState}
+     */
+    static from(object) {
+        return Object.assign(new MoveSetState(), object);
+    }
+}
+
+/**
+ * @param {Element} set
+ * @returns {MoveSetState}
+ */
+function getMoveSetState(set) {
+    let state = new MoveSetState(
+        set.querySelector('.move-set-title > h2').textContent,
+        Array.from(set.querySelectorAll('.move-box')).map(getMoveBoxState)
+    );
+
+    return state;
+}
+
+
+class PageState {
+    /**
+     * @param {(MoveBoxState|MoveSetState)[]} content
+     */
+    constructor(content) {
+        this.content = content
+    }
+
+    /**
+     * @param {Object} object 
+     * @returns {PageState}
+     */
+    static from(object) {
+        return Object.assign(new PageState(), object);
+    }
+}
+
+/**
+ * @returns {PageState}
+ */
+function getState() {
+    let state = new PageState([]);
+    let content = document.querySelectorAll('main > *');
+
+    for (const element of content) {
+        if (element.classList.contains('move-box')) {
+            let boxState = getMoveBoxState(element);
+
+            state.content.push(boxState);
+        } else if (element.classList.contains('move-set-container')) {
+            let setState = getMoveSetState(element);
+
+            state.content.push(setState);
+        }
+    }
+
+    return state;
+}
+
+/**
+ * @param {PageState} state 
+ * @returns {void}
+ */
+function saveState(state) {
+    localStorage.setItem('state', JSON.stringify(state));
+}
+
+
+/**
+ * @returns {void}
+ */
+function clearState() {
+    localStorage.removeItem('state')
+}
+
+
+/**
+ * @returns {PageState}
+ */
+function readState() {
+    return PageState.from(JSON.parse(localStorage.getItem('state')));
+}
+
+
+/**
+ * @returns {void}
+ */
+function clearContent() {
+    for (const element of document.querySelectorAll('.move-set-container')) {
+        element.remove()
+    }
+
+    for (const element of document.querySelectorAll('.move-box')) {
+        element.remove()
+    }
+}
+
+
+/**
+ * @param {PageState} state 
+ * @returns {void}
+ */
+function loadState(state) {
+    let main = document.querySelector('main');
+
+    for (const element of state.content) {
+        if (element.type === 'box') {
+            let box = createMoveBox(element)
+
+            initMoveBox(box);
+
+            main.appendChild(box);
+        } else if (element.type === 'set') {
+            let set = createMoveSetContainer(element)
+
+            initMoveSetContainer(set);
+
+            main.appendChild(set);
         }
     }
 }
 
 
 /**
- * @param {string} branch_1
- * @param {string} branch_2
- * @return {number}
+ * @param {MoveBoxState} state 
+ * @returns {Element}
  */
-function compareBranches(branch_1, branch_2) {
-    return branch_1.padEnd(branch_2.length, '0').localeCompare(branch_2.padEnd(branch_1.length, '0'));
+function createMoveBox(state) {
+    let box = document.createElement('button');
+
+    box.classList.add('move-box');
+
+    if (state.branch !== null) {
+        box.setAttribute('data-branch', state.branch);
+    }
+
+
+    if (state.moveClassification !== null) {
+        let moveClassification = document.createElement('div');
+
+        moveClassification.classList.add('move-classification');
+        moveClassification.classList.add(state.moveClassification);
+
+        box.appendChild(moveClassification);
+    }
+
+
+    let description = document.createElement('p');
+
+    description.textContent = state.description;
+    box.appendChild(description);
+
+
+    let board = document.createElement('div');
+
+    board.classList.add('move-board');
+
+    board.setAttribute('data-fen', state.fen)
+    board.setAttribute('data-perspective', state.perspective);
+    board.setAttribute('data-move-start', state.moveStart);
+    board.setAttribute('data-move-end', state.moveEnd);
+
+    box.appendChild(board);
+
+
+    return box;
 }
 
-// let 
-
-document.querySelectorAll('.move-set').forEach(set => {
-    let boxes = Array.from(set.querySelectorAll('.move-box'));
-
-    boxes.sort((a, b) => compareBranches(a.getAttribute('data-branch'), b.getAttribute('data-branch')))
-
-    let lines = 1;
-    let currentBranch = boxes[0].getAttribute('data-branch');
-
-    boxes.forEach(box => {
-        const observer = new MutationObserver(() => {
-            updateMoveBoxHeight(box);
-            toggleShowBoardsMode();
-        });
-
-        observer.observe(box, {
-            childList: false,
-            attributes: true,
-            subtree: false,
-        });
-
-        updateMoveBoxHeight(box);
-
-
-        let branch = box.getAttribute('data-branch');
-
-        if (compareBranches(branch, currentBranch) === 1) {
-            lines++;
-            currentBranch = branch;
-        }
-
-        box.style.gridRowStart = `${lines}`
-
-        
-        function showBranchBoards() {
-            let branchBoxes = boxes.filter((other_box) => other_box.getAttribute('data-branch').startsWith(box.getAttribute('data-branch')));
-
-            if (box.getAttribute('data-show-board') === 'true') {
-                branchBoxes.forEach((other_box) => other_box.setAttribute('data-show-board', 'false'))
-            } else {
-                branchBoxes.forEach((other_box) => other_box.setAttribute('data-show-board', 'true'))
-            }
-        }
-
-        box.addEventListener('dblclick', showBranchBoards)
-
-        let holdTimeoutID;
-        let holdTimeoutCalled = false;
-
-        box.addEventListener('mousedown', () => {
-            holdTimeoutID = setTimeout(() => {
-                showBranchBoards();
-
-                holdTimeoutCalled = true;
-
-                // let syntheticClick = new Event('click');
-
-                // box.dispatchEvent(syntheticClick);
-            }, 1500);
-
-            holdTimeoutCalled = false;
-        });
-
-        box.addEventListener('mouseup', () => {
-            clearTimeout(holdTimeoutID);
-
-            if (holdTimeoutCalled) {
-                let syntheticClick = new Event('click');
-
-                box.dispatchEvent(syntheticClick);
-            }
-        });
-
-        box.addEventListener('mouseleave', () => {
-            clearTimeout(holdTimeoutID);
-        });
-    })
-})
-
-
-document.querySelectorAll('.show-boards').forEach(button => {
-    button.setAttribute('data-hide-boards', 'false');
-
-    button.addEventListener('click', () => {
-        let moveBoxes = button.parentElement.parentElement.querySelectorAll('.move-box')
-
-        moveBoxes.forEach(box => {
-            box.setAttribute('data-show-board', button.getAttribute('data-hide-boards') === 'true' ? 'false' : 'true');
-        });
-
-        toggleShowBoardsMode();
-    })
-});
-
+/**
+ * @param {('light-square'|'dark-square')} squareColor 
+ * @param {boolean} highlight 
+ * @param {('wp'|'wn'|'wb'|'wr'|'wq'|'wk'|'bp'|'bn'|'bb'|'br'|'bq'|'bk'|null)} piece 
+ * @returns {Element}
+ */
 function createSquare(squareColor, highlight, piece) {
     let square = document.createElement('div');
 
@@ -171,7 +259,11 @@ function createSquare(squareColor, highlight, piece) {
     return square;
 }
 
-document.querySelectorAll('.move-board').forEach(board => {
+/**
+ * @param {Element} board 
+ * @returns {void}
+ */
+function initMoveBoard(board) {
     let squareColor = 'light-square';
 
     let perspective = board.getAttribute('data-perspective');
@@ -238,4 +330,234 @@ document.querySelectorAll('.move-board').forEach(board => {
         }
         squareColor = squareColor === 'light-square' ? 'dark-square' : 'light-square';
     }
-});
+}
+
+// document.querySelectorAll('.move-board').forEach(initMoveBoard);
+
+/**
+ * @param {Element} box 
+ * @returns {void}
+ */
+function switchShowBoard(box) {
+    box.setAttribute('data-show-board', box.getAttribute('data-show-board') === 'false' ? 'true' : 'false');
+}
+
+/**
+ * @param {Element} box 
+ * @returns {void}
+ */
+function initMoveBox(box) {
+    box.setAttribute('data-show-board', 'false');
+
+    box.addEventListener('click', () => {
+        switchShowBoard(box);
+    })
+
+    initMoveBoard(box.querySelector('.move-board'));
+}
+
+document.querySelectorAll('main > .move-box').forEach(initMoveBox);
+
+
+/**
+ * @param {MoveSetState} state
+ * @returns {Element}
+ */
+function createMoveSetContainer(state) {
+    let container = document.createElement('div');
+
+    container.classList.add('move-set-container');
+
+
+    let title = document.createElement('div');
+
+    title.classList.add('move-set-title');
+
+    let titleText = document.createElement('h2');
+    titleText.textContent = state.title;
+    title.appendChild(titleText);
+
+    let spacing = document.createTextNode(' ')
+    title.appendChild(spacing)
+
+    let showBoards = document.createElement('button');
+    showBoards.classList.add('show-boards');
+
+    let showBoardsIcon = document.createElement('div');
+    showBoardsIcon.classList.add('show-boards-icon');
+    showBoards.appendChild(showBoardsIcon);
+
+    title.appendChild(showBoards);
+
+    container.appendChild(title);
+
+
+    let set = document.createElement('div');
+
+    set.classList.add('move-set');
+
+    for (const moveBox of state.moveBoxes) {
+        let box = createMoveBox(moveBox);
+
+        set.appendChild(box);
+    }
+
+    container.appendChild(set);
+
+    return container;
+}
+
+/**
+ * @param {Element} button
+ * @returns {void}
+ */
+function initShowBoardsButton(button) {
+    button.setAttribute('data-hide-boards', 'false');
+
+    button.addEventListener('click', () => {
+        let moveBoxes = button.parentElement.parentElement.querySelectorAll('.move-box')
+
+        moveBoxes.forEach(box => {
+            box.setAttribute('data-show-board', button.getAttribute('data-hide-boards') === 'true' ? 'false' : 'true');
+        });
+
+        toggleShowBoardsMode();
+    })
+}
+
+/**
+ * @param {Element} box
+ * @returns {void}
+ */
+function updateMoveBoxHeight(box) {
+    if (box.getAttribute('data-show-board') === 'true') {
+        if (box.style.height !== '') {
+            box.style.height = ''
+        }
+    } else {
+        let height = `calc(${box.querySelector('p').clientHeight}px + 4 * var(--border-size))`
+
+        if (box.style.height !== height) {
+            box.style.height = height
+        }
+    }
+}
+
+/**
+ * @param {string} branch_1
+ * @param {string} branch_2
+ * @returns {number}
+ */
+function compareBranches(branch_1, branch_2) {
+    return branch_1.padEnd(branch_2.length, '0').localeCompare(branch_2.padEnd(branch_1.length, '0'));
+}
+
+/**
+ * @returns {void}
+ */
+function toggleShowBoardsMode() {
+    document.querySelectorAll('.move-set-title').forEach(title => {
+        let showBoardsButton = title.querySelector('.show-boards');
+        let hideBoards = false;
+
+        let set = title.nextElementSibling
+
+        if (set.querySelector('.move-box[data-show-board="false"]')) {
+            hideBoards = true;
+        }
+
+        showBoardsButton.setAttribute('data-hide-boards', hideBoards ? 'false' : 'true');
+    });
+}
+
+/**
+ * @param {Element} set 
+ * @returns {void}
+ */
+function initMoveSet(set) {
+    let boxes = Array.from(set.querySelectorAll('.move-box'));
+
+    boxes.forEach(initMoveBox);
+
+    boxes.sort((a, b) => compareBranches(a.getAttribute('data-branch'), b.getAttribute('data-branch')))
+
+    let lines = 1;
+    let currentBranch = boxes[0].getAttribute('data-branch');
+
+    boxes.forEach(box => {
+        const observer = new MutationObserver(() => {
+            updateMoveBoxHeight(box);
+            toggleShowBoardsMode();
+        });
+
+        observer.observe(box, {
+            childList: false,
+            attributes: true,
+            subtree: false,
+        });
+
+        updateMoveBoxHeight(box);
+
+
+        let branch = box.getAttribute('data-branch');
+
+        if (compareBranches(branch, currentBranch) === 1) {
+            lines++;
+            currentBranch = branch;
+        }
+
+        box.style.gridRowStart = `${lines}`
+
+        
+        function showBranchBoards() {
+            let branchBoxes = boxes.filter((other_box) => other_box.getAttribute('data-branch').startsWith(box.getAttribute('data-branch')));
+
+            if (box.getAttribute('data-show-board') === 'true') {
+                branchBoxes.forEach((other_box) => other_box.setAttribute('data-show-board', 'false'))
+            } else {
+                branchBoxes.forEach((other_box) => other_box.setAttribute('data-show-board', 'true'))
+            }
+        }
+
+        box.addEventListener('dblclick', showBranchBoards)
+
+        let holdTimeoutID;
+        let holdTimeoutCalled = false;
+
+        box.addEventListener('mousedown', () => {
+            holdTimeoutID = setTimeout(() => {
+                showBranchBoards();
+
+                holdTimeoutCalled = true;
+            }, 1500);
+
+            holdTimeoutCalled = false;
+        });
+
+        box.addEventListener('mouseup', () => {
+            clearTimeout(holdTimeoutID);
+
+            if (holdTimeoutCalled) {
+                let syntheticClick = new Event('click');
+
+                box.dispatchEvent(syntheticClick);
+            }
+        });
+
+        box.addEventListener('mouseleave', () => {
+            clearTimeout(holdTimeoutID);
+        });
+    })
+}
+
+/**
+ * @param {Element} container 
+ * @returns {void}
+ */
+function initMoveSetContainer(container) {
+    initShowBoardsButton(container.querySelector('.show-boards'));
+
+    initMoveSet(container.querySelector('.move-set'));
+}
+
+document.querySelectorAll('.move-set-container').forEach(initMoveSetContainer);


### PR DESCRIPTION
See README.md for latest changelog

v0.1 changes:
- Added saving and loading of the page using states and `window.localStorage`
  - State classes: `MoveBoxState`, `MoveSetState`, `PageState`
  - State getting functions: `getMoveBoxState`, `getMoveSetState`, `getState`
  - State manipulation functions: `saveState`, `clearState`
  - State loading functions: `loadState`, `createMoveBox`, `createMoveSetContainer`
  - Other functions: `readState`, `clearContent`
- Refactored parts of the code as functions so they can be used when loading states
  - Initialization functions: `initMoveBoard`, `initMoveBox`, `initShowBoardsButton`, `initMoveSet`, `initMoveSetContainer`
- Changed show boards button to not use a board character and instead have a background of a board (still has problems on Firefox and has inexact measures)
  - Added to do item about fixing the button (probably changing to an image)
- Fixed move classification path to images
- Added wrapping to the description of move boxes for later input capabilities
  - Changed HTML accordingly
- Added margin to move boxes that aren't children of move sets
- Added type documentation to `createSquare` function